### PR TITLE
Add missing properties to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,7 @@ version=0.1
 author=OpenElectronicsLab
 maintainer=eric@freesa.org
 sentence=The OpenHardwareExG is a platform for ECG, EEG, EMG, ENG, EOG, and evoked potential applications.
+paragraph=
+category=Device Control
 url=http://openelectronicslab.github.io/OpenHardwareExG/
 architectures=*


### PR DESCRIPTION
Missing paragraph property caused **Sketch > Include Library > Add .ZIP Library** installation to fail.

Missing category property caused the warning:
```
WARNING: Category '' in library OpenElectronicsLab OpenHardwareExG Arduino Shield is not valid. Setting to 'Uncategorized'
```
on every compile when using any recent version of the Arduino IDE.

Valid category values are listed in the Arduino Library Specification:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format